### PR TITLE
add options to packages and embed latex in png

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DESTDIR=$(HOME)/bin
+
 latest:
 	./mklatest
 clean:
@@ -9,3 +11,6 @@ doc:
 	pod2txt l2p doc/l2p.txt
 test:
 	cd vistest; make
+install:
+	install -m 0755 l2p $(DESTDIR)
+

--- a/README
+++ b/README
@@ -7,7 +7,7 @@ fragment of LaTeX code, without you needing to build a separate LaTeX
 markup file.  A large set of options provide great control and finesse
 over the resulting image.
 
-The LaTeX code used to generate the image is embedded in the images metadata,
+The LaTeX code used to generate the image is embedded in the image metadata,
 and can be extracted later, which allows the image to be modified in the future
 the future if needed.
 

--- a/README
+++ b/README
@@ -7,6 +7,10 @@ fragment of LaTeX code, without you needing to build a separate LaTeX
 markup file.  A large set of options provide great control and finesse
 over the resulting image.
 
+The LaTeX code used to generate the image is embedded in the images metadata,
+and can be extracted later, which allows the image to be modified in the future
+the future if needed.
+
 EXAMPLES
 
 l2p -i '$4x^2-7=\cos{2 \pi x}$' -o eqn4.png
@@ -36,6 +40,13 @@ Produce an image of the indicated infinite summation, padded with a
 border that is 20 pixels on each side horizontally, and 30 pixels each
 side vertically.  The color of this border region will be the same as
 the rest of the image background.
+
+l2p -X cosine.png
+
+Extract the LaTeX code used to produce the cosine.png image. LaTeX code is
+stored in the 'Comment' tag of a png file. The -X option reads the comment tag
+and writes it to a file named after the image file with a .latex extension. So,
+the above command would create a file named cosine.png.latex.
 
 Homepage: http://redsymbol.net/software/l2p/
 Public source repository: http://github.com/redsymbol/l2p/tree/master

--- a/l2p
+++ b/l2p
@@ -293,10 +293,10 @@ $pre = join "\n", (
 '\begin{center}',
 "");
 
-$post = <<'EOT';
-\end{center}
-\end{document}
-EOT
+$post = join "\n", (
+'\end{center}',
+'\end{document}',
+"");
 
 # discover the LaTeX expression to render
 @eqninput = ();
@@ -312,7 +312,7 @@ if (defined $opt_i) {
     # TODO: rewrite using an expression iterator subroutine
     while(<>) {
         chomp;
-        push @eqninput,  $_;
+        push @eqninput,  $_ unless( /^\s*#/ ); # skip comments
     }
 }
 $eqn = join("\n", @eqninput)."\n";

--- a/l2p
+++ b/l2p
@@ -3,303 +3,6 @@
 
 $version = '1.1.1';
 
-=head1 NAME
-
-l2p - create PNG images from LaTeX expressions
-
-=head1 SYNOPSIS
-
-B<l2p> [options...] -I 'I<latex math expression>'
-
-or
-
-B<l2p> [options...] [I<expression_file>]
-
-I<expression_file> contains an expression or expressions in (La)TeX
-format - one per line.  If neither I<expression_file>, nor the B<-I>
-or B<-i> options are given, the expression is read from standard
-input.
-
-=head1 DESCRIPTION
-
-Convert expressions in LaTeX format into PNGs and embeds the LaTeX code
-in the PNG Comment tag.
-
-=head1 EXAMPLES
-
-=over
-
-=item
-
-l2p -I '4x^2-7=\cos{2 \pi x}' -o 'eqn4.png'
-
-Produce a PNG image, named 'eqn4.png', of the equation described by the
-LaTeX expression '$4x^2 - 7 = \cos{2 \pi x}$'.
-
-=item
-
-l2p -i '$4x^2-7=\cos{2 \pi x}$' -o 'eqn4.png'
-
-Same as previous, except that the latex code argument is not
-automatically rendered as an equation - we must explicity surround it
-with '$' symbols.  By omitting that, you can also render
-images of non-math or mixed expressions.
-
-=item
-
-l2p -o big_equation.png big_hairy_equation
-
-Produce a PNG image, called big_equation.png, from the LaTeX expression
-contained in the file big_hairy_equation (specifically, it contains
-'$x=2$'.) Note that this file is NOT a full LaTeX document - use the
-B<-F> option for that.
-
-=item
-
-l2p -d 250 -I '\nabla \cdot \mathbf{D} = \rho'
-
-Produce a PNG image from the LaTeX code given with the B<-I> argument
-(which happens to be one of Maxwell's equations), at 250 dots per inch.
-Since we did not specify an output file name with the B<-o> option, the
-image will be 'eqn.png' (the default).  
-
-=item
-
-l2p -p amssymb -I '\mho' -o mho.png
-
-Produce a PNG image of the Mho symbol (an upside-down capital omega),
-saving the image in the file 'mho.png'.  We include the amssymb package,
-which defines that symbol.
-
-=item
-
-l2p -B 20x30 -I '\sum_{n=0}^{\infty}\frac{(-\phi^2)^n}{(2n)!}' -o cosine.png
-
-Produce an image of the indicated infinite summation, padded with a
-border that is 20 pixels on each side horizontally, and 30 pixels each
-side vertically.  The color of this border region will be the same as
-the rest of the image background.
-
-=back
-
-=head1 OPTIONS
-
-Many options have arguments that may contain characters, like '#' or
-spaces, that the shell considers special.  Be sure to surround all
-such arguments with single or double quotes, so that the shell
-understands what is meant.  (If unsure, it's always safe to use the
-quotes.)
-
-=over
-
-=item
-B<-I "math expression">
-
-Argument is an equation/expression in (La)TeX format, interpreted in
-math mode.  In most cases, you will want to enclose the argument in
-quotes to protect it from shell expansion.
-
-=item
-B<-i "latex code">
-
-Argument is a snippet of (La)TeX code.  If it is a math expression, be
-sure to surround it with $ symbols: for example, B<-i> "$x+2$".  In
-most cases, you will want to enclose the argument in quotes to protect
-it from shell expansion.
-
-The only difference between the B<-i> and B<-I> options is that B<-I>
-automatically surrounds its argument with "$" symbols, so that it is
-rendered in LaTeX's math mode.  Otherwise there is no difference.
-
-=item
-B<-b "rrggbb">
-
-Background color.  There are several ways to specify the color.  See the
-section L</COLORS>, below, for details.
-
-=item 
-B<-d dpi>
-
-Pixel density at which the equation is rendered, in dots per inch
-(default 300).  
-
-An image with a DPI of 600 will have twice as many pixels in each of the
-x and y directions than an image with a DPI of 300.  The effect is
-different in the normal context of printing, where a higher DPI will
-leave the text with the same physical size, but with a finer resolution.
-This is because the physical size of a pixel is not really variable; so
-to have double the resolution, a symbol in an image must be double the
-size.
-
-=item 
-B<-f "rrggbb">
-
-Foreground color.  There are several ways to specify the color.  See the
-section L</COLORS>, below, for details.
-
-=item
-B<-h>
-
-Show a help summary.
-
-=item 
-B<-o output.png>
-
-Name of output file.  Default is 'eqn.png'.
-
-=item
-B<-p packagename[:option1[,option2][/packagename2[,...]]]>
-
-Use additional LaTeX/TeX packages.  You can specify several, separated
-by slashes (or periods) and specify an option list for each.
-
-Example: -p siunitx:per-mode=fraction,mode=text/circuitikz
-
-=item
-B<-B "WIDTHxHEIGHT [color]">
-
-or: B<-B "SIZE [color]">
-
-Pad the resulting image with a border of the indicated size, in pixels. 
-
-You can optionally specify a color for the border region.  By default,
-the border will be the same color as the rest of the background. (See
-L</COLORS> below for the format.)
-
-=item
-B<-C>
-
-Suppress automatic removal (cleanup) of temporary files.  This will be
-useful if something goes wrong, or if you want to use the intermediate
-DVI or Postscript renditions.  B<l2p> will tell you which directory
-contains these files.
-
-=item
-B<-F>
-
-Supplied expression is a full LaTeX document, rather than just an
-expression fragment. Negates the B<-f>, B<-b>, B<-p>, B<-B> and B<-T>
-options.
-
-B<Note>:  B<l2p> currently only converts full LaTeX documents
-that are relatively simple: only one page in length, and with no external
-dependencies (such as included graphics).  If you need to convert a more
-complex document, you can generate a DVI file with latex like normal,
-then convert the DVI into a series of PNG images using B<convert> from
-the ImageMagick distribution.  See L<convert(1)>, or
-L<http://imagemagick.org/script/convert.php> for more information.
-
-=item
-B<-E 1|0>
-
-Enable or disable cropping the image to tight fit the equation using the -E
-option for the 'dvips' command. This will only work for text, it does not
-correctly crop the image for graphics. By default, this option is enabled, to
-disable it, give -E 0. See the -t option for graphics.
-
-=item
-B<-t>
-
-Crop the image using the -trim option for the 'convert' command. This should
-work for both equations and graphics, but you will likely want to specify
-a border width using the -B option.
-
-=item
-B<-T>
-
-Create an image with a transparent background.
-
-=item
-B<-X>
-
-Extract the LaTeX code used to create the image from the image comments. Currntly
-only supported for PNG images. LaTeX code is extracted and placed in a file with
-the same name as the image file with '.latex' added on the end.
-
-=item
-B<-P command>
-
-Preview the image with command after it is created.
-
-Example: -P feh
-
-This will open the image with feh.
-
-=item
-B<-V>
-
-Show version information.
-
-=back
-
-=head1 COLORS
-
-Some options, such as B<-b> and B<-f>, take an argument specifying a
-color in RGB format.  B<l2p> will decipher most representations, such
-as:
-
-=over
-
-=item
-
-A hexidecimal triplet.  For example, '-f "FF0000" -b "#ffffff"' gives a
-red foreground on a white background.  Case is not important, and the
-"#" is optional.
-
-=item
-
-Three decimal whole numbers, in the range of 0 to 255.  These must be
-separated by spaces or punctuation (comma, semicolon or colon).  For
-example, '-b "0 127 255" -f "0,0,0"' is black on a nice bluish
-background.
-
-=item
-
-Three fractions between 0 and 1, inclusive.  At least one of the three
-numbers must contain a decimal point (to distinguish this format from
-the others), and they are separated by space or punctuation.  For
-example, "0.87 .78 .41" is the same as the hex triplet "DEC769", and "0,
-1.0, 0" is the color green.  (Remember that decimal point.  "0, 1, 0"
-will give you a nearly black color.)
-
-=back
-
-Note that you may need to put single or double quotes around the color
-string, to ensure the shell interprets it correctly.
-
-=head1 BUGS
-
-Error handling is imperfect.  Among other things, If a needed 
-LaTeX package is not included, B<l2p> will silently produce a
-broken image.
-
-On certain platforms, images produced with the B<-T> option (transparent
-background) may leave pixels at the edges of symbols a mixture of the
-text color and some background color.  This may not look good if the
-resulting image is put on a differently colored background.  A
-workaround is to give a background color hint with the B<-b> option;
-the edge pixels will then be a mixture of specified foreground and
-background colors.
-
-=head1 ACKS
-
-Thanks to Jesse Merriman (L<http://www.jessemerriman.com/>) for
-providing a patch that improved transparent background support.
-Integrated in version 1.1.
-
-=head1 COPYRIGHT
-
-This software is in the public domain.
-
-=head1 AUTHOR
-
-Original: Aaron Maxwell (amax@redsymbol.net).  Comments, feature requests, and
-patches are welcome.
-
-Latest Commits: CD Clark III.
-
-=cut
-
 use File::Temp qw/tempfile tempdir/;
 use File::Basename;
 use Getopt::Std;
@@ -765,4 +468,301 @@ if ($opt_P) {
   $cmd = $opt_P." ".$outfile;
   system($cmd);
 }
+
+=head1 NAME
+
+l2p - create PNG images from LaTeX expressions
+
+=head1 SYNOPSIS
+
+B<l2p> [options...] -I 'I<latex math expression>'
+
+or
+
+B<l2p> [options...] [I<expression_file>]
+
+I<expression_file> contains an expression or expressions in (La)TeX
+format - one per line.  If neither I<expression_file>, nor the B<-I>
+or B<-i> options are given, the expression is read from standard
+input.
+
+=head1 DESCRIPTION
+
+Convert expressions in LaTeX format into PNGs and embeds the LaTeX code
+in the PNG Comment tag.
+
+=head1 EXAMPLES
+
+=over
+
+=item
+
+l2p -I '4x^2-7=\cos{2 \pi x}' -o 'eqn4.png'
+
+Produce a PNG image, named 'eqn4.png', of the equation described by the
+LaTeX expression '$4x^2 - 7 = \cos{2 \pi x}$'.
+
+=item
+
+l2p -i '$4x^2-7=\cos{2 \pi x}$' -o 'eqn4.png'
+
+Same as previous, except that the latex code argument is not
+automatically rendered as an equation - we must explicity surround it
+with '$' symbols.  By omitting that, you can also render
+images of non-math or mixed expressions.
+
+=item
+
+l2p -o big_equation.png big_hairy_equation
+
+Produce a PNG image, called big_equation.png, from the LaTeX expression
+contained in the file big_hairy_equation (specifically, it contains
+'$x=2$'.) Note that this file is NOT a full LaTeX document - use the
+B<-F> option for that.
+
+=item
+
+l2p -d 250 -I '\nabla \cdot \mathbf{D} = \rho'
+
+Produce a PNG image from the LaTeX code given with the B<-I> argument
+(which happens to be one of Maxwell's equations), at 250 dots per inch.
+Since we did not specify an output file name with the B<-o> option, the
+image will be 'eqn.png' (the default).  
+
+=item
+
+l2p -p amssymb -I '\mho' -o mho.png
+
+Produce a PNG image of the Mho symbol (an upside-down capital omega),
+saving the image in the file 'mho.png'.  We include the amssymb package,
+which defines that symbol.
+
+=item
+
+l2p -B 20x30 -I '\sum_{n=0}^{\infty}\frac{(-\phi^2)^n}{(2n)!}' -o cosine.png
+
+Produce an image of the indicated infinite summation, padded with a
+border that is 20 pixels on each side horizontally, and 30 pixels each
+side vertically.  The color of this border region will be the same as
+the rest of the image background.
+
+=back
+
+=head1 OPTIONS
+
+Many options have arguments that may contain characters, like '#' or
+spaces, that the shell considers special.  Be sure to surround all
+such arguments with single or double quotes, so that the shell
+understands what is meant.  (If unsure, it's always safe to use the
+quotes.)
+
+=over
+
+=item
+B<-I "math expression">
+
+Argument is an equation/expression in (La)TeX format, interpreted in
+math mode.  In most cases, you will want to enclose the argument in
+quotes to protect it from shell expansion.
+
+=item
+B<-i "latex code">
+
+Argument is a snippet of (La)TeX code.  If it is a math expression, be
+sure to surround it with $ symbols: for example, B<-i> "$x+2$".  In
+most cases, you will want to enclose the argument in quotes to protect
+it from shell expansion.
+
+The only difference between the B<-i> and B<-I> options is that B<-I>
+automatically surrounds its argument with "$" symbols, so that it is
+rendered in LaTeX's math mode.  Otherwise there is no difference.
+
+=item
+B<-b "rrggbb">
+
+Background color.  There are several ways to specify the color.  See the
+section L</COLORS>, below, for details.
+
+=item 
+B<-d dpi>
+
+Pixel density at which the equation is rendered, in dots per inch
+(default 300).  
+
+An image with a DPI of 600 will have twice as many pixels in each of the
+x and y directions than an image with a DPI of 300.  The effect is
+different in the normal context of printing, where a higher DPI will
+leave the text with the same physical size, but with a finer resolution.
+This is because the physical size of a pixel is not really variable; so
+to have double the resolution, a symbol in an image must be double the
+size.
+
+=item 
+B<-f "rrggbb">
+
+Foreground color.  There are several ways to specify the color.  See the
+section L</COLORS>, below, for details.
+
+=item
+B<-h>
+
+Show a help summary.
+
+=item 
+B<-o output.png>
+
+Name of output file.  Default is 'eqn.png'.
+
+=item
+B<-p packagename[:option1[,option2][/packagename2[,...]]]>
+
+Use additional LaTeX/TeX packages.  You can specify several, separated
+by slashes (or periods) and specify an option list for each.
+
+Example: -p siunitx:per-mode=fraction,mode=text/circuitikz
+
+=item
+B<-B "WIDTHxHEIGHT [color]">
+
+or: B<-B "SIZE [color]">
+
+Pad the resulting image with a border of the indicated size, in pixels. 
+
+You can optionally specify a color for the border region.  By default,
+the border will be the same color as the rest of the background. (See
+L</COLORS> below for the format.)
+
+=item
+B<-C>
+
+Suppress automatic removal (cleanup) of temporary files.  This will be
+useful if something goes wrong, or if you want to use the intermediate
+DVI or Postscript renditions.  B<l2p> will tell you which directory
+contains these files.
+
+=item
+B<-F>
+
+Supplied expression is a full LaTeX document, rather than just an
+expression fragment. Negates the B<-f>, B<-b>, B<-p>, B<-B> and B<-T>
+options.
+
+B<Note>:  B<l2p> currently only converts full LaTeX documents
+that are relatively simple: only one page in length, and with no external
+dependencies (such as included graphics).  If you need to convert a more
+complex document, you can generate a DVI file with latex like normal,
+then convert the DVI into a series of PNG images using B<convert> from
+the ImageMagick distribution.  See L<convert(1)>, or
+L<http://imagemagick.org/script/convert.php> for more information.
+
+=item
+B<-E 1|0>
+
+Enable or disable cropping the image to tight fit the equation using the -E
+option for the 'dvips' command. This will only work for text, it does not
+correctly crop the image for graphics. By default, this option is enabled, to
+disable it, give -E 0. See the -t option for graphics.
+
+=item
+B<-t>
+
+Crop the image using the -trim option for the 'convert' command. This should
+work for both equations and graphics, but you will likely want to specify
+a border width using the -B option.
+
+=item
+B<-T>
+
+Create an image with a transparent background.
+
+=item
+B<-X>
+
+Extract the LaTeX code used to create the image from the image comments. Currntly
+only supported for PNG images. LaTeX code is extracted and placed in a file with
+the same name as the image file with '.latex' added on the end.
+
+=item
+B<-P command>
+
+Preview the image with command after it is created.
+
+Example: -P feh
+
+This will open the image with feh.
+
+=item
+B<-V>
+
+Show version information.
+
+=back
+
+=head1 COLORS
+
+Some options, such as B<-b> and B<-f>, take an argument specifying a
+color in RGB format.  B<l2p> will decipher most representations, such
+as:
+
+=over
+
+=item
+
+A hexidecimal triplet.  For example, '-f "FF0000" -b "#ffffff"' gives a
+red foreground on a white background.  Case is not important, and the
+"#" is optional.
+
+=item
+
+Three decimal whole numbers, in the range of 0 to 255.  These must be
+separated by spaces or punctuation (comma, semicolon or colon).  For
+example, '-b "0 127 255" -f "0,0,0"' is black on a nice bluish
+background.
+
+=item
+
+Three fractions between 0 and 1, inclusive.  At least one of the three
+numbers must contain a decimal point (to distinguish this format from
+the others), and they are separated by space or punctuation.  For
+example, "0.87 .78 .41" is the same as the hex triplet "DEC769", and "0,
+1.0, 0" is the color green.  (Remember that decimal point.  "0, 1, 0"
+will give you a nearly black color.)
+
+=back
+
+Note that you may need to put single or double quotes around the color
+string, to ensure the shell interprets it correctly.
+
+=head1 BUGS
+
+Error handling is imperfect.  Among other things, If a needed 
+LaTeX package is not included, B<l2p> will silently produce a
+broken image.
+
+On certain platforms, images produced with the B<-T> option (transparent
+background) may leave pixels at the edges of symbols a mixture of the
+text color and some background color.  This may not look good if the
+resulting image is put on a differently colored background.  A
+workaround is to give a background color hint with the B<-b> option;
+the edge pixels will then be a mixture of specified foreground and
+background colors.
+
+=head1 ACKS
+
+Thanks to Jesse Merriman (L<http://www.jessemerriman.com/>) for
+providing a patch that improved transparent background support.
+Integrated in version 1.1.
+
+=head1 COPYRIGHT
+
+This software is in the public domain.
+
+=head1 AUTHOR
+
+Original: Aaron Maxwell (amax@redsymbol.net).  Comments, feature requests, and
+patches are welcome.
+
+Latest Commits: CD Clark III.
+
+=cut
 

--- a/l2p
+++ b/l2p
@@ -527,9 +527,10 @@ if ($opt_X) {
   $comment = $magick->Get( "comment" );
 
   $latexfn = "$image.latex";
-  open($latexfh,">",$latexfn) or die "could not write to latex file";
-  print $latexfh $comment;
-  close($latexfh);
+  #open($latexfh,">",$latexfn) or die "could not write to latex file";
+  #print $latexfh $comment;
+  #close($latexfh);
+  print $comment;
 
   exit(0);
 }

--- a/l2p
+++ b/l2p
@@ -190,11 +190,12 @@ the ImageMagick distribution.  See L<convert(1)>, or
 L<http://imagemagick.org/script/convert.php> for more information.
 
 =item
-B<-E>
+B<-E 1|0>
 
-Crop the image to tight fit the equation using the -E option for the 'dvips' command. This will
-only work for text, it does not correctly crop the image for graphics. See the -t option
-for graphics.
+Enable or disable cropping the image to tight fit the equation using the -E
+option for the 'dvips' command. This will only work for text, it does not
+correctly crop the image for graphics. By default, this option is enabled, to
+disable it, give -E 0. See the -t option for graphics.
 
 =item
 B<-t>
@@ -485,7 +486,7 @@ Options:
     -f 'rrggbb'       foreground color
     -b 'rrggbb'       background color
     -d dpi            Conversion resolution (default 300)
-    -E 0|1            Enable/disabel cropping image with dvips -E option (does not work for graphics). Enabled by default.
+    -E 1|0            Enable/disabel cropping image with dvips -E option (does not work for graphics). Enabled by default.
     -t                Trim image with convert -trim option (works for graphics)
     -T                Transparent background
     -p pkg[,pkg2...]  use TeX/LaTeX package(s)

--- a/l2p
+++ b/l2p
@@ -22,7 +22,8 @@ input.
 
 =head1 DESCRIPTION
 
-Convert expressions in LaTeX format into PNGs
+Convert expressions in LaTeX format into PNGs and embeds the LaTeX code
+in the PNG Comment tag.
 
 =head1 EXAMPLES
 
@@ -147,10 +148,12 @@ B<-o output.png>
 Name of output file.  Default is 'eqn.png'.
 
 =item
-B<-p packagename[,packagename2[,...]]]>
+B<-p packagename[:option1[,option2][/packagename2[,...]]]>
 
 Use additional LaTeX/TeX packages.  You can specify several, separated
-by commas.
+by slashes (or periods) and specify an option list for each.
+
+Example: -p siunitx:per-mode=fraction,mode=text/circuitikz
 
 =item
 B<-B "WIDTHxHEIGHT [color]">
@@ -187,9 +190,39 @@ the ImageMagick distribution.  See L<convert(1)>, or
 L<http://imagemagick.org/script/convert.php> for more information.
 
 =item
+B<-E>
+
+Crop the image to tight fit the equation using the -E option for the 'dvips' command. This will
+only work for text, it does not correctly crop the image for graphics. See the -t option
+for graphics.
+
+=item
+B<-t>
+
+Crop the image using the -trim option for the 'convert' command. This should
+work for both equations and graphics, but you will likely want to specify
+a border width using the -B option.
+
+=item
 B<-T>
 
 Create an image with a transparent background.
+
+=item
+B<-X>
+
+Extract the LaTeX code used to create the image from the image comments. Currntly
+only supported for PNG images. LaTeX code is extracted and placed in a file with
+the same name as the image file with '.latex' added on the end.
+
+=item
+B<-P command>
+
+Preview the image with command after it is created.
+
+Example: -P feh
+
+This will open the image with feh.
 
 =item
 B<-V>
@@ -259,8 +292,10 @@ This software is in the public domain.
 
 =head1 AUTHOR
 
-Aaron Maxwell (amax@redsymbol.net).  Comments, feature requests, and
+Original: Aaron Maxwell (amax@redsymbol.net).  Comments, feature requests, and
 patches are welcome.
+
+Latest Commits: CD Clark III.
 
 =cut
 
@@ -355,6 +390,8 @@ our($opt_o, # output file name
     $opt_f, # foreground RGB triplet
     $opt_b, # background RGB triplet
     $opt_F, # set if input is a full LaTeX document
+    $opt_E, # crop image with dvips -E option
+    $opt_t, # trim image with imagemagick -trim
     $opt_T, # transparent background 
     $opt_C, # suppress autocleaning of temp files
     $opt_h, # display help message
@@ -363,6 +400,7 @@ our($opt_o, # output file name
     $opt_B, # border
     $opt_X, # extract latex code
     $opt_Z, # reserved for hacks
+    $opt_P, # preview image after it is generated
     );
 
 # check to see if needed software is available
@@ -370,6 +408,8 @@ my %cmds = (
     'latex'    => '',
     'dvips'    => '',
     'convert'  => '',
+    'mogrify'  => '',
+    'identify' => '',
     );
 my @cmds_notfound;
 foreach $cmd (keys %cmds) {
@@ -385,7 +425,7 @@ if(@cmds_notfound) {
 
 # process command line opts
 $cmdline = $0." ".join(" ", @ARGV);
-getopt('odiIfbpBx');
+getopt('odiIfbpBxP');
 
 if ($opt_V) {
 	print $version, "\n";
@@ -422,6 +462,8 @@ Options:
     -f 'rrggbb'       foreground color
     -b 'rrggbb'       background color
     -d dpi            Conversion resolution (default 300)
+    -E                Crop image with dvips -E option (does not work for graphics)
+    -t                Trim image with convert -trim option (works for graphics)
     -T                Transparent background
     -p pkg[,pkg2...]  use TeX/LaTeX package(s)
     -C                Suppress removal (cleanup) of temporary files
@@ -429,6 +471,7 @@ Options:
     -V                Show version
     -B 'geom [color]' Pad image with a border
     -X                Extract (La)TeX code from image file
+    -P 'command'      Preview image with command after creating
     -h                Show this help and exit
 Also see the full documentation (try typing 'perldoc l2p').
 EOT
@@ -503,7 +546,7 @@ if ($opt_T) {
 
 my @packages = ('color');
 if ($opt_p) {
-	@packages = (@packages, split(/,/, $opt_p));
+	@packages = (@packages, split(/[\.\+\/]/, $opt_p));
 }
 
 # get expression to render
@@ -588,7 +631,7 @@ EOT
 
 # convert dvi to ps
 # the -E option prevents convert from freaking out later
-my $dvipscmd = "$cmds{'dvips'} " . ($opt_F ? "": "-E") . " foo -o 2>/dev/null";
+my $dvipscmd = "$cmds{'dvips'} " . ( $opt_F ? "": ( $opt_E ? "-E" : "" )) . " foo -o 2>/dev/null";
 system("cd $tempdir; $dvipscmd");
 unless (-e "${tempdir}/foo.ps") {
 	print STDERR <<'EOT';
@@ -609,7 +652,7 @@ if($opt_F) { # make image of full latex document
 	'PixelsPerInch',
 	'-density',
 	"$dpi",
-        );
+  );
 }
 if ($opt_T) { # transparent background
     @cargs = (
@@ -639,6 +682,12 @@ if($opt_B) {
     $color = '#' . norm2hex($color);
     unshift @cargs, ('-border', $geom, '-bordercolor', $color);
 }
+# Trim
+if($opt_t) {
+  # we want to trim the picture
+  unshift @cargs, ('-trim');
+}
+
 unshift @cargs, ("$cmds{'convert'}");
 $dest_img = "${tempdir}/dest_img";
 push @cargs, (
@@ -672,3 +721,11 @@ if( "${out_format}" eq "png" )
 
 # rename final png
 system("cp ${dest_img} $outfile");
+
+
+# preview image with the command provided
+if ($opt_P) {
+  $cmd = $opt_P." ".$outfile;
+  system($cmd);
+}
+

--- a/l2p
+++ b/l2p
@@ -128,8 +128,6 @@ my %cmds = (
     'latex'    => '',
     'dvips'    => '',
     'convert'  => '',
-    'mogrify'  => '',
-    'identify' => '',
     );
 my @cmds_notfound;
 foreach $cmd (keys %cmds) {

--- a/l2p
+++ b/l2p
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 # L2P - Convert LaTeX expressions to PNG
 
-$version = '1.1.1';
+$version = 'Unknown';
 
 use File::Temp qw/tempfile tempdir/;
 use File::Basename;
@@ -102,7 +102,8 @@ sub extract_ext($) {
 
 
 my($pre,$post,$dpi,@eqninput,$eqn,$outfile,$fg,$bg);
-our($opt_o, # output file name
+our($opt_a, # auto mode
+    $opt_o, # output file name
     $opt_d, # dpi
     $opt_i, # in-command-line latex code
     $opt_x, # file type extension
@@ -145,6 +146,21 @@ if(@cmds_notfound) {
 $cmdline = basename($0)." ".join(" ", @ARGV);
 $opt_E = 1;  # enable -E cropping by default
 getopt('odiIfbpBxPE');
+
+if( $opt_a )
+{
+  $inputfn = shift @ARGV;
+  open($inputfh,"<",$inputfn) or die "Could not open input file ($inputfn).\n";
+  while($_ = <$inputfh>)
+  {
+    if( s/^\s*%\s*CMD: // )
+    {
+      system( $_ );
+    }
+  }
+  close $inputfh;
+  exit(0);
+}
 
 # if -trim cropping is enabled, turn off -E cropping.
 if( $opt_t )
@@ -458,6 +474,7 @@ if( "${out_format}" eq "png" )
 }
 
 # rename final png
+
 system("cp ${dest_img} $outfile");
 
 

--- a/l2p
+++ b/l2p
@@ -634,8 +634,15 @@ EOT
 if( "${out_format}" eq "png" )
 {
 # put latex code in the metadata of png
+open($latexfh,"<",$latexfn) or die "could not read from latex temp file";
+# this line creates the comment that will be inserted into the png file.
+# it turns out to be kind of tricky to print a string with latex command because it is full of things that look like special characters.
+# example: \newcommand{\result}[1]{\bf #1}      both \n and \r can be interpolated.
+# so, are going to read the latex from the tmp file so we can get the lines into an array, then we quotemeta each line, and finally joing them with newline chars.
+$comment = join("\n", (map { chomp; quotemeta($_) } <$latexfh>) );
+close($latexfh);
 @cargs = ("-comment"
-         , join("\n",($pre,$eqn,$post))
+         , $comment
          , ${dest_img}
 );
 unshift @cargs, ("$cmds{'mogrify'}");

--- a/l2p
+++ b/l2p
@@ -478,7 +478,7 @@ if ($opt_p) {
 # get expression to render
 $pre = join "\n", (
 '\documentclass{article}',
-(map { '\usepackage{' . $_ . '}' } @packages),
+(map { my ($p,$o) = split(/:/, $_); '\usepackage['.($o ? $o : "").']{' . $p. '}' } @packages),
 '\definecolor{bg}{rgb}{', $bg, '}',
 '\definecolor{fg}{rgb}{', $fg, '}',
 '\pagestyle{empty}',

--- a/l2p
+++ b/l2p
@@ -425,7 +425,15 @@ if(@cmds_notfound) {
 
 # process command line opts
 $cmdline = $0." ".join(" ", @ARGV);
-getopt('odiIfbpBxP');
+$opt_E = 1;  # enable -E cropping by default
+getopt('odiIfbpBxPE');
+
+# if -trim cropping is enabled, turn off -E cropping.
+if( $opt_t )
+{
+  $opt_E = 0;
+  print $opt_E;
+}
 
 if ($opt_V) {
 	print $version, "\n";
@@ -462,7 +470,7 @@ Options:
     -f 'rrggbb'       foreground color
     -b 'rrggbb'       background color
     -d dpi            Conversion resolution (default 300)
-    -E                Crop image with dvips -E option (does not work for graphics)
+    -E 0|1            Enable/disabel cropping image with dvips -E option (does not work for graphics). Enabled by default.
     -t                Trim image with convert -trim option (works for graphics)
     -T                Transparent background
     -p pkg[,pkg2...]  use TeX/LaTeX package(s)

--- a/l2p
+++ b/l2p
@@ -301,6 +301,7 @@ Latest Commits: CD Clark III.
 =cut
 
 use File::Temp qw/tempfile tempdir/;
+use File::Basename;
 use Getopt::Std;
 
 my $HAVE_PERLMAGICK = eval {
@@ -440,7 +441,7 @@ if(@cmds_notfound) {
 }
 
 # process command line opts
-$cmdline = $0." ".join(" ", @ARGV);
+$cmdline = basename($0)." ".join(" ", @ARGV);
 $opt_E = 1;  # enable -E cropping by default
 getopt('odiIfbpBxPE');
 
@@ -448,7 +449,6 @@ getopt('odiIfbpBxPE');
 if( $opt_t )
 {
   $opt_E = 0;
-  print $opt_E;
 }
 
 if ($opt_V) {
@@ -748,7 +748,7 @@ if( "${out_format}" eq "png" )
     # open the png file and write the latex code into the comments field
     my $magick = Image::Magick->new();
     $magick->Read( $dest_img );
-    unshift @eqninput, '" '.$cmdline; # put the command line used to generate the file in the comments
+    unshift @eqninput, '%CMD: '.$cmdline; # put the command line used to generate the file in the comments
     $magick->Set( Comment=> join("\n", ( map {quotemeta($_)} @eqninput) )."\n" );
     $magick->Write( $dest_img );
   }

--- a/l2p
+++ b/l2p
@@ -368,6 +368,7 @@ my %cmds = (
     'latex'   => '',
     'dvips'   => '',
     'convert' => '',
+    'mogrify' => '',
     );
 my @cmds_notfound;
 foreach $cmd (keys %cmds) {
@@ -628,6 +629,19 @@ unless (-e $dest_img) {
 Sorry, something went wrong.  Final conversion from postscript format has failed.
 EOT
     exit(2);
+}
+
+if( "${out_format}" eq "png" )
+{
+# put latex code in the metadata of png
+@cargs = ("-comment"
+         , join("\n",($pre,$eqn,$post))
+         , ${dest_img}
+);
+unshift @cargs, ("$cmds{'mogrify'}");
+
+#print join(" ",@cargs);
+system(@cargs);
 }
 
 # rename final png

--- a/l2p
+++ b/l2p
@@ -266,6 +266,7 @@ patches are welcome.
 
 use File::Temp qw/tempfile tempdir/;
 use Getopt::Std;
+use Image::Magick;
 
 # Takes a string and extracts an RGB value from it.
 # Returns ($r,$g,$b), all values between 0 and 1 if parsing is successful,
@@ -345,7 +346,7 @@ sub extract_ext($) {
 }
 
 
-my($pre,$post,$dpi,$eqn,$outfile,$fg,$bg);
+my($pre,$post,$dpi,@eqninput,$eqn,$outfile,$fg,$bg);
 our($opt_o, # output file name
     $opt_d, # dpi
     $opt_i, # in-command-line latex code
@@ -360,15 +361,15 @@ our($opt_o, # output file name
     $opt_p, # additional package(s)
     $opt_V, # print version info
     $opt_B, # border
+    $opt_X, # extract latex code
     $opt_Z, # reserved for hacks
     );
 
 # check to see if needed software is available
 my %cmds = (
-    'latex'   => '',
-    'dvips'   => '',
-    'convert' => '',
-    'mogrify' => '',
+    'latex'    => '',
+    'dvips'    => '',
+    'convert'  => '',
     );
 my @cmds_notfound;
 foreach $cmd (keys %cmds) {
@@ -383,6 +384,7 @@ if(@cmds_notfound) {
 }
 
 # process command line opts
+$cmdline = $0." ".join(" ", @ARGV);
 getopt('odiIfbpBx');
 
 if ($opt_V) {
@@ -426,10 +428,38 @@ Options:
     -F                Input is full LaTeX document, not just fragment
     -V                Show version
     -B 'geom [color]' Pad image with a border
+    -X                Extract (La)TeX code from image file
     -h                Show this help and exit
 Also see the full documentation (try typing 'perldoc l2p').
 EOT
 	exit(0);
+}
+
+if ($opt_X) {
+  print "Extracting (La)TeX code from image file";
+
+  $image = shift @ARGV;
+  if(not -e $image ) {
+      die "image file ($image) does not exist!";
+  } elsif (not -r $image) {
+      die "Cannot read file $image.";
+  }
+  if(substr($image,0,1) ne '/') {
+      my $cwd = `pwd`; chomp $cwd;
+      $image= $cwd . '/' . $image;
+  }
+
+  my $magick = Image::Magick->new();
+  $magick->Read( $image );
+  
+  $comment = $magick->Get( "comment" );
+
+  $latexfn = "$image.latex";
+  open($latexfh,">",$latexfn) or die "could not write to latex file";
+  print $latexfh $comment;
+  close($latexfh);
+
+  exit(0);
 }
 
 $dpi =  $opt_d || 300;
@@ -495,27 +525,24 @@ $post = <<'EOT';
 EOT
 
 # discover the LaTeX expression to render
+@eqninput = ();
 $eqn='';
 if (defined $opt_i) {
     # latex code from command line
-    $eqn =  $opt_i . "\n";
+    push @eqninput, $opt_i;
 } elsif (defined $opt_I) {
     # expression from command line
-    $eqn = sprintf("\$%s\$\n",$opt_I);
+    push @eqninput, sprintf("\$%s\$",$opt_I);
 } elsif (not $opt_F) {
     # file/stdin contains LaTeX expression(s)
     # TODO: rewrite using an expression iterator subroutine
     while(<>) {
-        next if /^\s*#/ or /^\s*$/;
-            chomp; 
-        $eqn .= $_ . "\n";
-        # If this is line contains a single inline expression, add
-        # an extra newline, so that it renders correctly
-        if (/^\s*\$.*\$\s*$/) {
-            $eqn .= "\n";
-        }
+        chomp;
+        push @eqninput,  $_;
+    }
 }
-}
+$eqn = join("\n", @eqninput)."\n";
+
 if (not $opt_F and $eqn =~ /^\s*$/) {
     print STDERR <<'EOT';
 Did not find a LaTeX expression to render.  Perhaps the supplied
@@ -633,22 +660,14 @@ EOT
 
 if( "${out_format}" eq "png" )
 {
-# put latex code in the metadata of png
-open($latexfh,"<",$latexfn) or die "could not read from latex temp file";
-# this line creates the comment that will be inserted into the png file.
-# it turns out to be kind of tricky to print a string with latex command because it is full of things that look like special characters.
-# example: \newcommand{\result}[1]{\bf #1}      both \n and \r can be interpolated.
-# so, are going to read the latex from the tmp file so we can get the lines into an array, then we quotemeta each line, and finally joing them with newline chars.
-$comment = join("\n", (map { chomp; quotemeta($_) } <$latexfh>) );
-close($latexfh);
-@cargs = ("-comment"
-         , $comment
-         , ${dest_img}
-);
-unshift @cargs, ("$cmds{'mogrify'}");
 
-#print join(" ",@cargs);
-system(@cargs);
+  # open the png file and write the latex code into the comments field
+  my $magick = Image::Magick->new();
+  $magick->Read( $dest_img );
+  unshift @eqninput, '" '.$cmdline; # put the command line used to generate the file in the comments
+  $magick->Set( Comment=> join("\n", ( map {quotemeta($_)} @eqninput) )."\n" );
+  $magick->Write( $dest_img );
+
 }
 
 # rename final png

--- a/l2p
+++ b/l2p
@@ -301,7 +301,22 @@ Latest Commits: CD Clark III.
 
 use File::Temp qw/tempfile tempdir/;
 use Getopt::Std;
-use Image::Magick;
+
+my $HAVE_PERLMAGICK = eval {
+        require Image::Magick;
+        1;
+};
+if( $HAVE_PERLMAGICK )
+{
+  Image::Magick->import();
+}
+else
+{
+  $PERLMAGICK_MISSING_MSG  = "Embedding/extracting LaTeX code in/from image requires the Image::Magick (PerlMagick) package, which was not found.";
+  $PERLMAGICK_MISSING_MSG .= "\n";
+  $PERLMAGICK_MISSING_MSG .= "Please install it or update your environment so that it can be found if you want to use this feature.";
+  $PERLMAGICK_MISSING_MSG .= "\n";
+}
 
 # Takes a string and extracts an RGB value from it.
 # Returns ($r,$g,$b), all values between 0 and 1 if parsing is successful,
@@ -488,6 +503,11 @@ EOT
 
 if ($opt_X) {
   print "Extracting (La)TeX code from image file";
+
+  if(not $HAVE_PERLMAGICK)
+  {
+    die $PERLMAGICK_MISSING_MSG;
+  }
 
   $image = shift @ARGV;
   if(not -e $image ) {
@@ -715,15 +735,22 @@ EOT
     exit(2);
 }
 
+# add LaTeX to image metadata
 if( "${out_format}" eq "png" )
 {
-
-  # open the png file and write the latex code into the comments field
-  my $magick = Image::Magick->new();
-  $magick->Read( $dest_img );
-  unshift @eqninput, '" '.$cmdline; # put the command line used to generate the file in the comments
-  $magick->Set( Comment=> join("\n", ( map {quotemeta($_)} @eqninput) )."\n" );
-  $magick->Write( $dest_img );
+  if( not ${HAVE_PERLMAGICK} )
+  {
+    print $PERLMAGICK_MISSING_MSG;
+  }
+  else
+  {
+    # open the png file and write the latex code into the comments field
+    my $magick = Image::Magick->new();
+    $magick->Read( $dest_img );
+    unshift @eqninput, '" '.$cmdline; # put the command line used to generate the file in the comments
+    $magick->Set( Comment=> join("\n", ( map {quotemeta($_)} @eqninput) )."\n" );
+    $magick->Write( $dest_img );
+  }
 
 }
 

--- a/l2p
+++ b/l2p
@@ -229,11 +229,11 @@ if ($opt_X) {
   
   $comment = $magick->Get( "comment" );
 
-  $latexfn = "$image.latex";
-  #open($latexfh,">",$latexfn) or die "could not write to latex file";
-  #print $latexfh $comment;
-  #close($latexfh);
-  print $comment;
+  $latexfn = $opt_o || "/dev/stdout";  #$image.latex";
+  open($latexfh,">",$latexfn) or die "could not write to latex file";
+  print $latexfh $comment;
+  close($latexfh);
+  #print $comment;
 
   exit(0);
 }


### PR DESCRIPTION
I'm not sure if you are interested in these changes since it does not look like the code has been updated in several years, but I found l2p recently and like it.

These commits allow packages options to be specified by giving the option after the package name separated by a colon, i.e. -p package:option,package2...

In addition, the latex file used to generate the png is inserted into th epng's comment meta data, so that it could be extracted in the future if the picture needs to be edited.
